### PR TITLE
Closing SSH client and deleting SSH Object

### DIFF
--- a/src/tngsdk/benchmark/pdriver/osm/__init__.py
+++ b/src/tngsdk/benchmark/pdriver/osm/__init__.py
@@ -254,6 +254,12 @@ class OsmDriver(object):
             self._collect_experiment_results(ec, function)
             LOG.info(stdout)
 
+        LOG.info(f'Closing SSH Connection to {function}')
+        # Close the SSH connection to prevent any possible memory leaks from paramiko
+        self.ssh_clients[function].close()
+        # Delete the SSH object all together
+        del self.ssh_clients[function]
+
         self.conn_mgr.client.ns.delete(ec.name, wait=True)
         self.conn_mgr.client.nsd.delete(self.nsd_id)
         LOG.info("Deleted service: {}".format(self.nsi_uuid))
@@ -262,7 +268,6 @@ class OsmDriver(object):
         for probe_vnfd_id_i in self.probe_vnfd_id:
             self.conn_mgr.client.vnfd.delete(probe_vnfd_id_i)
         LOG.info("Deleted Probe VNFD: {}".format(self.probe_vnfd_id))
-
     def teardown_platform(self):
         # self.conn_mgr.client.vim.delete("trial_vim")
         pass

--- a/src/tngsdk/benchmark/pdriver/osm/__init__.py
+++ b/src/tngsdk/benchmark/pdriver/osm/__init__.py
@@ -268,6 +268,7 @@ class OsmDriver(object):
         for probe_vnfd_id_i in self.probe_vnfd_id:
             self.conn_mgr.client.vnfd.delete(probe_vnfd_id_i)
         LOG.info("Deleted Probe VNFD: {}".format(self.probe_vnfd_id))
+
     def teardown_platform(self):
         # self.conn_mgr.client.vim.delete("trial_vim")
         pass


### PR DESCRIPTION
This is done because some experiments crash after 10 runs when using the OSM pdriver.