### PR TITLE
Dynamic routing update now tested using openstack

### DIFF
--- a/src/tngsdk/benchmark/pdriver/osm/__init__.py
+++ b/src/tngsdk/benchmark/pdriver/osm/__init__.py
@@ -200,10 +200,10 @@ class OsmDriver(object):
                     time.sleep(3)
                     if "input" in function:
                         stdin, stdout, stderr = self.ssh_clients[function].exec_command(
-                            f'sudo ip route add {self.config.get("data_2_subnet")} via {self.main_vm_data_ip_2}')
+                            f'sudo ip route add {self.config.get("data_2_subnet")} via {self.main_vm_data_ip_1}')
                     elif "output" in function:
                         stdin, stdout, stderr = self.ssh_clients[function].exec_command(
-                            f'sudo ip route add {self.config.get("data_1_subnet")} via {self.main_vm_data_ip_1}')
+                            f'sudo ip route add {self.config.get("data_1_subnet")} via {self.main_vm_data_ip_2}')
                     else:
                         stdin, stdout, stderr = self.ssh_clients[function].exec_command(
                             f'sudo sysctl -w net.ipv4.ip_forward=1')


### PR DESCRIPTION
The user must specify the subnets of the data networks in the tng-bench config file. This is now a requirement when using OSM to perform experiments 