### PR TITLE
Restart connection to OSM at the start of every ex exec.

### DIFF
--- a/src/tngsdk/benchmark/pdriver/osm/__init__.py
+++ b/src/tngsdk/benchmark/pdriver/osm/__init__.py
@@ -153,6 +153,9 @@ class OsmDriver(object):
         probe_username = self.config.get('probe_username')
         probe_password = self.config.get('probe_password')
 
+        # Renew connection to prevent OSM Client connection from expiring
+        self.conn_mgr.connect()
+
         login_uname = None
         login_pass = None
         # Begin executing commands


### PR DESCRIPTION
During a very long experiment we ran into a scenario where the execution stopped because the OSM Auth token had expired. I modified the pdriver so that the connection is restarted at the beginning of every experiment execution to prevent this expiration from happening again. 